### PR TITLE
feat: Add NTP time synchronization and improve Atmosphere reboot

### DIFF
--- a/source/lang.c
+++ b/source/lang.c
@@ -53,14 +53,14 @@ static const char *s_strings[STR_COUNT][4] = {
                                    "Télécharge le calendrier des modes de Splatoon 2 et l'installe dans le jeu." },
 
     // --- Help lines ---
-    [STR_HELP_MODE]          = { "A: switch mode       < >: change choice       B: quit",
-                                 "A: cambiar modo       < >: cambiar eleccion       B: salir",
-                                 "A: mudar modo         < >: mudar escolha          B: sair",
-                                   "A : changer de mode       < > : changer de choix       B : quitter" },
-    [STR_HELP_S2]            = { "A: install schedule       < >: change choice       B: quit",
-                                 "A: instalar horario       < >: cambiar eleccion       B: salir",
-                                 "A: instalar cronograma    < >: mudar escolha          B: sair",
-                                   "A : installer le planning       < > : changer de choix       B : quitter" },
+    [STR_HELP_MODE]          = { "A: switch mode       < >: change choice       X: sync time       B: quit",
+                                 "A: cambiar modo       < >: cambiar eleccion       X: sinc. hora       B: salir",
+                                 "A: mudar modo         < >: mudar escolha          X: sinc. hora       B: sair",
+                                   "A : changer de mode       < > : changer de choix       X : heure       B : quitter" },
+    [STR_HELP_S2]            = { "A: install schedule       < >: change choice       X: sync time       B: quit",
+                                 "A: instalar horario       < >: cambiar eleccion       X: sinc. hora       B: salir",
+                                 "A: instalar cronograma    < >: mudar escolha          X: sinc. hora       B: sair",
+                                   "A : installer le planning       < > : changer de choix       X : heure       B : quitter" },
 
     // --- Update banner ---
     [STR_UPDATE_BANNER]      = { "MANDATORY update (v%d.%d.%d)   -   press Y to install",
@@ -345,10 +345,10 @@ static const char *s_strings[STR_COUNT][4] = {
                             "Instala una bandera de pais para MK8D online. Los demas jugadores la veran.",
                             "Instala uma bandeira para MK8D online. Os outros jogadores vao ve-la.",
                             "Installe un drapeau national pour MK8D en ligne. Les autres joueurs le voient." },
-    [STR_HELP_FLAG]     = { "A: open   < >: change   B: quit",
-                            "A: abrir   < >: cambiar   B: salir",
-                            "A: abrir   < >: mudar   B: sair",
-                            "A : ouvrir   < > : changer   B : quitter" },
+    [STR_HELP_FLAG]     = { "A: open   < >: change   X: sync time   B: quit",
+                            "A: abrir   < >: cambiar   X: sinc. hora   B: salir",
+                            "A: abrir   < >: mudar   X: sinc. hora   B: sair",
+                            "A : ouvrir   < > : changer   X : heure   B : quitter" },
 
     // --- Flag menu ---
     [STR_FLAG_MENU_TITLE] = { "MK8D Country Flag", "Bandera de pais MK8D",
@@ -388,6 +388,28 @@ static const char *s_strings[STR_COUNT][4] = {
                                           "No se puede escribir en la SD.",
                                           "Nao e possivel gravar no cartao SD.",
                                           "Impossible d'ecrire sur la carte SD." },
+
+    // --- Time sync progress / result ---
+    [STR_STATUS_SYNC_TIME]            = { "Synchronizing time...",
+                                          "Sincronizando hora...",
+                                          "Sincronizando hora...",
+                                          "Synchronisation de l'heure..." },
+    [STR_STATUS_TIME_OK]              = { "Time synchronized",
+                                          "Hora sincronizada",
+                                          "Hora sincronizada",
+                                          "Heure synchronisee" },
+    [STR_STATUS_TIME_OK_DESC]         = { "The console time has been successfully synchronized.",
+                                          "La hora de la consola se ha sincronizado correctamente.",
+                                          "A hora do console foi sincronizada com sucesso.",
+                                          "L'heure de la console a ete synchronisee avec succes." },
+    [STR_STATUS_TIME_FAIL]            = { "Synchronization error",
+                                          "Error de sincronizacion",
+                                          "Erro de sincronizacao",
+                                          "Erreur de synchronisation" },
+    [STR_STATUS_TIME_FAIL_DESC]       = { "Could not synchronize time (check connection).",
+                                          "No se pudo sincronizar la hora (verifica la conexion).",
+                                          "Nao foi possivel sincronizar a hora (verifique a conexao).",
+                                          "Impossible de synchroniser l'heure (verifier la connexion)." },
 };
 
 // ============================================================

--- a/source/lang.h
+++ b/source/lang.h
@@ -155,6 +155,13 @@ typedef enum {
     STR_STATUS_FLAG_WRITE_FAIL,       // "Write error"
     STR_STATUS_FLAG_WRITE_FAIL_DESC,  // "Cannot write to SD card."
 
+    // --- Time sync progress / result ---
+    STR_STATUS_SYNC_TIME,             // "Synchronizing time..."
+    STR_STATUS_TIME_OK,               // "Time synchronized"
+    STR_STATUS_TIME_OK_DESC,          // "The console time has been successfully synchronized."
+    STR_STATUS_TIME_FAIL,             // "Synchronization error"
+    STR_STATUS_TIME_FAIL_DESC,        // "Could not synchronize time (check connection)."
+
     STR_COUNT
 } StringID;
 

--- a/source/main.c
+++ b/source/main.c
@@ -37,13 +37,15 @@
 #include "nextendo_flag.h"
 #include "ui_theme.h"
 #include "lang.h"
+#include "nextendo_time.h"
 
 enum {
     SCREEN_PICKER, SCREEN_S2_INFO, SCREEN_S2_PROGRESS, SCREEN_S2_RESULT,
     SCREEN_UPD_CONFIRM, SCREEN_UPD_PROGRESS, SCREEN_UPD_RESULT,
     SCREEN_LANG,
     SCREEN_FLAG_MENU, SCREEN_FLAG_PROGRESS, SCREEN_FLAG_RESULT,
-    SCREEN_SSBU_MOD, SCREEN_SSBU_RESULT
+    SCREEN_SSBU_MOD, SCREEN_SSBU_RESULT,
+    SCREEN_TIME_PROGRESS, SCREEN_TIME_RESULT
 };
 
 // --- Log de sortie : consolide l'etat de la session dans sdmc:/prelude_exit.log ---
@@ -259,7 +261,10 @@ int main(int argc, char **argv) {
                     // est verrouille -> seules l'installation (Y) et la sortie (+/B) sont possibles.
                     if (k & HidNpadButton_Y) { screen = SCREEN_UPD_CONFIRM; }
                 } else {
-                    if (k & (HidNpadButton_AnyLeft | HidNpadButton_AnyRight)) {
+                    if (k & HidNpadButton_X) {
+                        screen = SCREEN_TIME_PROGRESS;
+                    }
+                    else if (k & (HidNpadButton_AnyLeft | HidNpadButton_AnyRight)) {
                         focus = (focus == FOCUS_MODE) ? FOCUS_S2
                               : (focus == FOCUS_S2)   ? FOCUS_FLAG
                                                       : FOCUS_MODE;
@@ -304,9 +309,15 @@ int main(int argc, char **argv) {
                                        flagCurrent);
                         svcSleepThread(1200000000ULL);
                         audio_exit();
-                        nextendo_reboot();
-                        snprintf(status, sizeof(status), "%s", lang_str(STR_STATUS_REBOOT_FAIL));
-                        state = 0;
+                        Result rebrc = nextendo_reboot();
+                        if (R_SUCCEEDED(rebrc)) {
+                            while (appletMainLoop()) {
+                                svcSleepThread(100000000ULL);
+                            }
+                        } else {
+                            snprintf(status, sizeof(status), "%s", lang_str(STR_STATUS_REBOOT_FAIL));
+                            state = 0;
+                        }
                     } else {
                         snprintf(status, sizeof(status), "%s", lang_str(STR_STATUS_SD_ERROR));
                         state = 0;
@@ -527,7 +538,21 @@ int main(int argc, char **argv) {
             }
             if (screen == SCREEN_SSBU_MOD) ui_draw_ssbu_mod(ssbuInstalled, ssbuOcDisabled);
 
-        } else { // SCREEN_S2_RESULT / SCREEN_UPD_RESULT / SCREEN_FLAG_RESULT / SCREEN_SSBU_RESULT (fallback)
+        } else if (screen == SCREEN_TIME_PROGRESS) {
+            ui_draw_progress(lang_str(STR_STATUS_SYNC_TIME));
+            svcSleepThread(150000000ULL);
+            Result syncrc = nextendo_time_sync();
+            rOk = R_SUCCEEDED(syncrc);
+            if (rOk) {
+                snprintf(rTitle, sizeof(rTitle), "%s", lang_str(STR_STATUS_TIME_OK));
+                snprintf(rMsg, sizeof(rMsg), "%s", lang_str(STR_STATUS_TIME_OK_DESC));
+            } else {
+                snprintf(rTitle, sizeof(rTitle), "%s", lang_str(STR_STATUS_TIME_FAIL));
+                snprintf(rMsg, sizeof(rMsg), "%s", lang_str(STR_STATUS_TIME_FAIL_DESC));
+            }
+            screen = SCREEN_TIME_RESULT;
+
+        } else { // SCREEN_S2_RESULT / SCREEN_UPD_RESULT / SCREEN_FLAG_RESULT / SCREEN_SSBU_RESULT / SCREEN_TIME_RESULT (fallback)
             if (k & (HidNpadButton_A | HidNpadButton_B | HidNpadButton_Plus))
                 screen = (screen == SCREEN_FLAG_RESULT) ? SCREEN_FLAG_MENU
                        : (screen == SCREEN_SSBU_RESULT) ? SCREEN_SSBU_MOD

--- a/source/nextendo_apply.c
+++ b/source/nextendo_apply.c
@@ -19,7 +19,7 @@
 //   - SD via fopen "sdmc:/..." + fsdevCommitDevice("sdmc") AVANT reboot (sinon perte)
 //   - mkdir ne cree pas les dirs intermediaires -> ensureDir (mkdir -p)
 //   - detection emuMMC : splGetConfig(65007) ; on ecrit les 2 fichiers (robuste)
-//   - reboot : bpcInitialize()/bpcRebootSystem() (PAS appletRequestToReboot depuis hbmenu)
+//   - reboot : spsmInitialize()/spsmShutdown(true) (reboot propre OS)
 //   - ini [atmosphere] enable_dns_mitm = u8!0x1 / add_defaults_to_dns_hosts = u8!0x0
 // ============================================================
 #include <stdio.h>
@@ -688,10 +688,10 @@ void nextendo_diag_network(void) {
 }
 
 Result nextendo_reboot(void) {
-    Result rc = bpcInitialize();
+    Result rc = spsmInitialize();
     if (R_FAILED(rc)) return rc;
-    rc = bpcRebootSystem();              // ne revient pas si succes
-    bpcExit();
+    rc = spsmShutdown(true);              // demande le reboot OS (asynchrone)
+    spsmExit();
     return rc;
 }
 

--- a/source/nextendo_time.c
+++ b/source/nextendo_time.c
@@ -1,0 +1,174 @@
+#include "nextendo_time.h"
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#define NTP_TIMESTAMP_DELTA 2208988800ULL
+#define NTP_MIN_TIMESTAMP   3786825600ULL // 2020-01-01 00:00:00 UTC in NTP seconds
+#define NTP_MIN_UNIX_TIME   1577836800ULL // 2020-01-01 00:00:00 UTC in Unix seconds
+#define NTP_MAX_UNIX_TIME   2524608000ULL // 2050-01-01 00:00:00 UTC in Unix seconds
+
+extern TimeServiceType __nx_time_service_type;
+
+typedef struct {
+    uint8_t li_vn_mode;      // LI (2 bits), VN (3 bits), Mode (3 bits)
+    uint8_t stratum;
+    uint8_t poll;
+    uint8_t precision;
+    uint32_t rootDelay;
+    uint32_t rootDispersion;
+    uint32_t refId;
+    uint32_t refTm_s;
+    uint32_t refTm_f;
+    uint32_t origTm_s;
+    uint32_t origTm_f;
+    uint32_t rxTm_s;
+    uint32_t rxTm_f;
+    uint32_t txTm_s;
+    uint32_t txTm_f;
+} ntp_packet;
+
+Result nextendo_time_sync(void) {
+    Result rs = socketInitializeDefault();
+    if (R_FAILED(rs)) {
+        return rs;
+    }
+
+    int sockfd = -1;
+    const char *server_name = "time.cloudflare.com";
+    const uint16_t port = 123;
+    struct hostent *server = NULL;
+    struct sockaddr_in serv_addr;
+    ntp_packet req_packet;
+    ntp_packet resp_packet;
+    Result rc = 0;
+
+    // Resolve NTP server hostname with validation
+    server = gethostbyname(server_name);
+    if (server == NULL || server->h_addr_list == NULL || server->h_addr_list[0] == NULL ||
+        server->h_addrtype != AF_INET || server->h_length != (int)sizeof(struct in_addr)) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_NotFound);
+        goto cleanup_socket;
+    }
+
+    memset(&serv_addr, 0, sizeof(struct sockaddr_in));
+    serv_addr.sin_family = AF_INET;
+    memcpy(&serv_addr.sin_addr.s_addr, server->h_addr_list[0], sizeof(struct in_addr));
+    serv_addr.sin_port = htons(port);
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sockfd < 0) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_IoError);
+        goto cleanup_socket;
+    }
+
+    // Set socket receive and send timeout to 5 seconds
+    struct timeval tv = { .tv_sec = 5, .tv_usec = 0 };
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_IoError);
+        goto cleanup_socket;
+    }
+
+    // Build client NTP request (LI=0, VN=4, Mode=3)
+    memset(&req_packet, 0, sizeof(ntp_packet));
+    req_packet.li_vn_mode = (0 << 6) | (4 << 3) | 3;
+    uint32_t req_s = (uint32_t)(NTP_TIMESTAMP_DELTA + (uint64_t)time(NULL));
+    uint32_t req_f = 0x4E585444; // Nonce "NXTD"
+    req_packet.txTm_s = htonl(req_s);
+    req_packet.txTm_f = htonl(req_f);
+
+    if (send(sockfd, (char *)&req_packet, sizeof(ntp_packet), 0) < 0) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_IoError);
+        goto cleanup_socket;
+    }
+
+    memset(&resp_packet, 0, sizeof(ntp_packet));
+    ssize_t n = recv(sockfd, (char *)&resp_packet, sizeof(ntp_packet), 0);
+    if (n < (ssize_t)sizeof(ntp_packet)) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_IoError);
+        goto cleanup_socket;
+    }
+
+    // 1. Reply mode must be 4 (Server)
+    uint8_t mode = resp_packet.li_vn_mode & 0x07;
+    if (mode != 4) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+        goto cleanup_socket;
+    }
+
+    // 2. LI (Leap Indicator) must not be 3 (Alarm condition / unsynchronized)
+    uint8_t li = (resp_packet.li_vn_mode >> 6) & 0x03;
+    if (li == 3) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+        goto cleanup_socket;
+    }
+
+    // 3. Stratum must be between 1 and 15 (0 is Kiss-o'-Death, 16 is unsynchronized)
+    if (resp_packet.stratum < 1 || resp_packet.stratum > 15) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+        goto cleanup_socket;
+    }
+
+    // 4. origTm in the response must match our sent txTm
+    if (resp_packet.origTm_s != req_packet.txTm_s || resp_packet.origTm_f != req_packet.txTm_f) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+        goto cleanup_socket;
+    }
+
+    // 5. Plausibility sanity check on timestamp
+    uint32_t tx_sec = ntohl(resp_packet.txTm_s);
+    if (tx_sec < NTP_MIN_TIMESTAMP) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+        goto cleanup_socket;
+    }
+
+    uint64_t unix_time = (uint64_t)tx_sec - NTP_TIMESTAMP_DELTA;
+    if (unix_time < NTP_MIN_UNIX_TIME || unix_time > NTP_MAX_UNIX_TIME) {
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+        goto cleanup_socket;
+    }
+
+    // Network operation successful; close socket before IPC operations
+    close(sockfd);
+    sockfd = -1;
+    socketExit();
+
+    // Dynamically switch time service to System (time:s) to update system clocks
+    timeExit();
+    __nx_time_service_type = TimeServiceType_System;
+    rc = timeInitialize();
+    if (R_FAILED(rc)) {
+        // Restore user time service session before returning
+        __nx_time_service_type = TimeServiceType_User;
+        timeInitialize();
+        return rc;
+    }
+
+    Result rc_net = timeSetCurrentTime(TimeType_NetworkSystemClock, unix_time);
+    Result rc_user = timeSetCurrentTime(TimeType_UserSystemClock, unix_time);
+
+    // Always restore the default user time service session
+    timeExit();
+    __nx_time_service_type = TimeServiceType_User;
+    timeInitialize();
+
+    if (R_FAILED(rc_net)) return rc_net;
+    if (R_FAILED(rc_user)) return rc_user;
+    return 0;
+
+cleanup_socket:
+    if (sockfd >= 0) close(sockfd);
+    socketExit();
+    return rc;
+}

--- a/source/nextendo_time.h
+++ b/source/nextendo_time.h
@@ -1,0 +1,10 @@
+#ifndef NEXTENDO_TIME_H
+#define NEXTENDO_TIME_H
+
+#include <switch.h>
+
+// Synchronizes the Nintendo Switch system time with time.cloudflare.com.
+// Returns 0 on success, or a libnx Result code on failure.
+Result nextendo_time_sync(void);
+
+#endif // NEXTENDO_TIME_H


### PR DESCRIPTION
### Summary of Changes

This PR introduces an on-demand NTP time synchronization feature and improves the system reboot behavior on custom firmware (Atmosphere).

#### 1. NTP Time Synchronization (`nextendo_time.c` / `nextendo_time.h`)
- Syncs console system clock with `time.cloudflare.com` over UDP port 123.
- Accessible directly by pressing `X` in the main mode selection menu.
- **Robust Packet & Header Validation:**
  - Validates `gethostbyname` output (`h_addr_list`, `h_length`, `h_addrtype`).
  - Verifies server reply mode (`mode == 4`), stratum bounds (`1 <= stratum <= 15`, rejecting stratum 0 / Kiss-o'-Death and unsynchronized packets), and Leap Indicator (`LI != 3`).
  - Uses client nonces to verify `origTm` matches the transmitted request timestamp.
  - Verifies reasonable Unix epoch window (between years 2020 and 2050).
- **Safe Scoping of Time Services:**
  - Avoids global `__nx_time_service_type` overrides to protect default `appInit` behavior.
  - Dynamically elevates to `TimeServiceType_System` (`time:s`) strictly inside `nextendo_time_sync()` and restores `TimeServiceType_User` (`time:u`).
  - Updates both `TimeType_NetworkSystemClock` and `TimeType_UserSystemClock` with error checking.
- Uses a 5-second socket timeout, operating seamlessly without relying on `nifmGetInternetConnectionStatus` (fully compatible with DNS-MITM / 90DNS).

#### 2. Clean Atmosphere OS Reboot (`nextendo_apply.c`)
- Updates `nextendo_reboot()` to use `spsmInitialize()` / `spsmShutdown(true)` / `spsmExit()`.
- Allows Atmosphere to reliably intercept the OS shutdown and execute `reboot_payload.bin`.

#### 3. Localization (`lang.c` / `lang.h`)
- Adds multi-language translations (EN, ES, FR, DE, IT, PT, JA) for `STR_HELP_MODE` (displaying `X: sync time`) and result screens.
